### PR TITLE
feat: Photo 사진 모델 & 뷰 그리기, 모든 구조를 Rectangle 클래스가 아닌 Shape로 추상화

### DIFF
--- a/Drawing-iPad/Source/Model/Factorys/Protocols/ShapeCreatable.swift
+++ b/Drawing-iPad/Source/Model/Factorys/Protocols/ShapeCreatable.swift
@@ -5,7 +5,6 @@
 //  Created by 박효준 on 9/20/24.
 //
 
-// TODO: 팩토리 구현 어떻게 할지 생각해보기
 protocol ShapeCreatable {
     associatedtype ShapeType: (Shapable & AlphaControllable)
     

--- a/Drawing-iPad/Source/Model/Factorys/Protocols/ShapeCreatable.swift
+++ b/Drawing-iPad/Source/Model/Factorys/Protocols/ShapeCreatable.swift
@@ -6,7 +6,7 @@
 //
 
 protocol ShapeCreatable {
-    associatedtype ShapeType: (Shapable & AlphaControllable)
+    associatedtype ShapeType: BaseShape
     
     func makeShape() -> ShapeType
 }

--- a/Drawing-iPad/Source/Model/Plane.swift
+++ b/Drawing-iPad/Source/Model/Plane.swift
@@ -9,19 +9,19 @@ import Foundation
 
 // TODO: struct로 만들 경우 mutating을 붙여야 함, struct 안에 class가 있는 구조의 문제는 없나 ?
 final class Plane {
-    private var rectangles: [Rectangle] {
+    private var shapes: [BaseShape] {
         didSet {
             postPlaneChangedNotification()
         }
     }
-    var count: Int { self.rectangles.count }
+    var count: Int { self.shapes.count }
     
-    init(rectangles: [Rectangle]) {
-        self.rectangles = rectangles
+    init(shapes: [BaseShape]) {
+        self.shapes = shapes
     }
     
     convenience init() {
-        self.init(rectangles: [])
+        self.init(shapes: [])
     }
     
     private func postPlaneChangedNotification() {
@@ -29,26 +29,26 @@ final class Plane {
         NotificationCenter.default.post(name: .planeUpdated, object: nil)
     }
     
-    func appendRectangle(rectangle: Rectangle) {
-        self.rectangles.append(rectangle)
+    func appendShape(shape: BaseShape) {
+        self.shapes.append(shape)
     }
     
     func containsRectangle(at origin: Point) -> Bool {
-        self.rectangles.contains {
+        self.shapes.contains {
             $0.origin == origin
         }
     }
     
-    func rectangle(withID identifier: UUID) -> Rectangle? {
-        return rectangles.first { $0.identifier == identifier }
+    func findShape(withID identifier: UUID) -> BaseShape? {
+        return shapes.first { $0.identifier == identifier }
     }
 }
 
 // MARK: - Subscript 구현
 
 extension Plane {
-    subscript(index: Int) -> Rectangle? {
-        guard index >= 0 && index < rectangles.count else { return nil }
-        return rectangles[index]
+    subscript(index: Int) -> BaseShape? {
+        guard index >= 0 && index < shapes.count else { return nil }
+        return shapes[index]
     }
 }

--- a/Drawing-iPad/Source/Model/Shapes/ShapeCategory.swift
+++ b/Drawing-iPad/Source/Model/Shapes/ShapeCategory.swift
@@ -1,0 +1,13 @@
+//
+//  ShapeCategory.swift
+//  Drawing-iPad
+//
+//  Created by 박효준 on 9/20/24.
+//
+
+import Foundation
+
+enum ShapeCategory {
+    case rectangle
+    case photo
+}

--- a/Drawing-iPad/Source/View/CanvasView.swift
+++ b/Drawing-iPad/Source/View/CanvasView.swift
@@ -43,6 +43,7 @@ final class CanvasView: UIView {
     init() {
         super.init(frame: .zero)
         rectangleCreatorButton.delegate = self
+        photoCreatorButton.delegate = self
         sideView.delegate = self
         setupConfiguration()
     }

--- a/Drawing-iPad/Source/View/CanvasView.swift
+++ b/Drawing-iPad/Source/View/CanvasView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol CanvasViewDelegate: AnyObject {
-    func didTapShapeButtonInCanvasView(_ canvasView: CanvasView)
+    func didTapShapeCreatorButtonInCanvasView(_ canvasView: CanvasView)
     func didTapGestureRectangle(_ canvasView: CanvasView, rectangleID: UUID)
     func didTapBackgroundColorChangeButton(_ canvasView: CanvasView)
     func didChangeAlphaSlider(_ canvasView: CanvasView, changedValue: Float)
@@ -33,7 +33,7 @@ final class CanvasView: UIView {
     
     init() {
         super.init(frame: .zero)
-        rectangleButton.delegate = self
+        rectangleCreatorButton.delegate = self
         sideView.delegate = self
         setupConfiguration()
     }
@@ -95,9 +95,8 @@ final class CanvasView: UIView {
 // MARK: - ShapeCreatorButtonDelegate
 
 extension CanvasView: ShapeCreatorButtonDelegate {
-    func didTapShapeButton(_ button: ShapeCreatorButton) {
-        print("캔버스뷰 델리게이트")
-        delegate?.didTapShapeButtonInCanvasView(self)
+    func didTapShapeCreatorButton(_ button: ShapeCreatorButton) {
+        delegate?.didTapShapeCreatorButtonInCanvasView(self)
     }
 }
 

--- a/Drawing-iPad/Source/View/CanvasView.swift
+++ b/Drawing-iPad/Source/View/CanvasView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol CanvasViewDelegate: AnyObject {
     func didTapShapeCreatorButtonInCanvasView(_ canvasView: CanvasView, shapeCategory: ShapeCategory)
-    func didTapGestureRectangle(_ canvasView: CanvasView, rectangleID: UUID)
+    func didTapGestureShapeView(_ canvasView: CanvasView, shapeID: UUID)
     func didTapBackgroundColorChangeButton(_ canvasView: CanvasView)
     func didChangeAlphaSlider(_ canvasView: CanvasView, changedValue: Float)
 }
@@ -86,15 +86,15 @@ final class CanvasView: UIView {
         ])
     }
     
-    func addRectangle(rectangleView: BaseShapeView) {
-        rectangleView.delegate = self
-        planeView.addSubview(rectangleView)
+    func addShape(shapeView: BaseShapeView) {
+        shapeView.delegate = self
+        planeView.addSubview(shapeView)
         
         NSLayoutConstraint.activate([
-            rectangleView.leadingAnchor.constraint(equalTo: planeView.leadingAnchor, constant: rectangleView.frame.origin.x),
-            rectangleView.topAnchor.constraint(equalTo: planeView.topAnchor, constant: rectangleView.frame.origin.y),
-            rectangleView.widthAnchor.constraint(equalToConstant: rectangleView.frame.width),
-            rectangleView.heightAnchor.constraint(equalToConstant: rectangleView.frame.height)
+            shapeView.leadingAnchor.constraint(equalTo: planeView.leadingAnchor, constant: shapeView.frame.origin.x),
+            shapeView.topAnchor.constraint(equalTo: planeView.topAnchor, constant: shapeView.frame.origin.y),
+            shapeView.widthAnchor.constraint(equalToConstant: shapeView.frame.width),
+            shapeView.heightAnchor.constraint(equalToConstant: shapeView.frame.height)
         ])
     }
     
@@ -102,10 +102,10 @@ final class CanvasView: UIView {
         return planeView.bounds.size
     }
     
-    func rectangleView(withID id: UUID) -> BaseShapeView? {
+    func shapeView(withID id: UUID) -> BaseShapeView? {
         return planeView.subviews
             .compactMap { $0 as? BaseShapeView }
-            .first { $0.rectangleID == id }
+            .first { $0.shapeID == id }
     }
 }
 
@@ -120,8 +120,8 @@ extension CanvasView: ShapeCreatorButtonDelegate {
 // MARK: - RectangleTapGestureDelegate
 
 extension CanvasView: ShapeViewDelegate {
-    func didTapRectangleGesture(_ rectangleView: BaseShapeView) {
-        delegate?.didTapGestureRectangle(self, rectangleID: rectangleView.rectangleID)
+    func didTapShapeView(_ shapeView: BaseShapeView) {
+        delegate?.didTapGestureShapeView(self, shapeID: shapeView.shapeID)
     }
     
     func updateSideView(shape: BaseShape) {

--- a/Drawing-iPad/Source/View/CanvasView.swift
+++ b/Drawing-iPad/Source/View/CanvasView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol CanvasViewDelegate: AnyObject {
-    func didTapShapeCreatorButtonInCanvasView(_ canvasView: CanvasView)
+    func didTapShapeCreatorButtonInCanvasView(_ canvasView: CanvasView, shapeCategory: ShapeCategory)
     func didTapGestureRectangle(_ canvasView: CanvasView, rectangleID: UUID)
     func didTapBackgroundColorChangeButton(_ canvasView: CanvasView)
     func didChangeAlphaSlider(_ canvasView: CanvasView, changedValue: Float)
@@ -21,7 +21,16 @@ final class CanvasView: UIView {
     
     // MARK: - UI Components
     
-    private let rectangleButton = ShapeCreatorButton(name: "사각형")
+    private let rectangleCreatorButton = ShapeCreatorButton(name: "사각형", shapeCategory: .rectangle)
+    private let photoCreatorButton = ShapeCreatorButton(name: "사진", shapeCategory: .photo)
+    private let creatorButtonStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 5
+        stackView.distribution = .fillEqually
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
     private let sideView = SideView()
     private let planeView: UIView = {
         let view = UIView()
@@ -46,23 +55,30 @@ final class CanvasView: UIView {
     // MARK: - Method
     
     private func setupConfiguration() {
-        self.addSubview(rectangleButton)
+        self.addSubview(creatorButtonStackView)
         self.addSubview(sideView)
         self.addSubview(planeView)
         self.translatesAutoresizingMaskIntoConstraints = false
+        [rectangleCreatorButton, photoCreatorButton].forEach {
+            creatorButtonStackView.addArrangedSubview($0)
+        }
         
         NSLayoutConstraint.activate([
-            rectangleButton.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            rectangleButton.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor),
-            rectangleButton.widthAnchor.constraint(equalToConstant: 150),
-            rectangleButton.heightAnchor.constraint(equalToConstant: 150),
+            creatorButtonStackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            creatorButtonStackView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor),
+            rectangleCreatorButton.widthAnchor.constraint(equalToConstant: 150),
+            rectangleCreatorButton.heightAnchor.constraint(equalToConstant: 150),
+            
+            photoCreatorButton.widthAnchor.constraint(equalToConstant: 150),
+            photoCreatorButton.heightAnchor.constraint(equalToConstant: 150),
+            
             
             sideView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             sideView.widthAnchor.constraint(equalToConstant: 220),
             sideView.topAnchor.constraint(equalTo: self.topAnchor),
             sideView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             
-            planeView.bottomAnchor.constraint(equalTo: self.rectangleButton.topAnchor),
+            planeView.bottomAnchor.constraint(equalTo: self.rectangleCreatorButton.topAnchor),
             planeView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             planeView.topAnchor.constraint(equalTo: self.topAnchor),
             planeView.trailingAnchor.constraint(equalTo: self.sideView.leadingAnchor)
@@ -95,8 +111,8 @@ final class CanvasView: UIView {
 // MARK: - ShapeCreatorButtonDelegate
 
 extension CanvasView: ShapeCreatorButtonDelegate {
-    func didTapShapeCreatorButton(_ button: ShapeCreatorButton) {
-        delegate?.didTapShapeCreatorButtonInCanvasView(self)
+    func didTapShapeCreatorButton(_ button: ShapeCreatorButton, shapeCategory: ShapeCategory) {
+        delegate?.didTapShapeCreatorButtonInCanvasView(self, shapeCategory: shapeCategory)
     }
 }
 
@@ -107,8 +123,8 @@ extension CanvasView: RectangleTapGestureDelegate {
         delegate?.didTapGestureRectangle(self, rectangleID: rectangleView.rectangleID)
     }
     
-    func updateSideView(rectangle: Rectangle) {
-        sideView.updateRectangleInfo(rectangle: rectangle)
+    func updateSideView(shape: BaseShape) {
+        sideView.updateShapeInfo(shape: shape)
     }
 }
 

--- a/Drawing-iPad/Source/View/CanvasView.swift
+++ b/Drawing-iPad/Source/View/CanvasView.swift
@@ -86,7 +86,7 @@ final class CanvasView: UIView {
         ])
     }
     
-    func addRectangle(rectangleView: RectangleView) {
+    func addRectangle(rectangleView: BaseShapeView) {
         rectangleView.delegate = self
         planeView.addSubview(rectangleView)
         
@@ -102,9 +102,9 @@ final class CanvasView: UIView {
         return planeView.bounds.size
     }
     
-    func rectangleView(withID id: UUID) -> RectangleView? {
+    func rectangleView(withID id: UUID) -> BaseShapeView? {
         return planeView.subviews
-            .compactMap { $0 as? RectangleView }
+            .compactMap { $0 as? BaseShapeView }
             .first { $0.rectangleID == id }
     }
 }
@@ -119,8 +119,8 @@ extension CanvasView: ShapeCreatorButtonDelegate {
 
 // MARK: - RectangleTapGestureDelegate
 
-extension CanvasView: RectangleTapGestureDelegate {
-    func didTapRectangleGesture(_ rectangleView: RectangleView) {
+extension CanvasView: ShapeViewDelegate {
+    func didTapRectangleGesture(_ rectangleView: BaseShapeView) {
         delegate?.didTapGestureRectangle(self, rectangleID: rectangleView.rectangleID)
     }
     

--- a/Drawing-iPad/Source/View/Component/ShapeCreatorButton.swift
+++ b/Drawing-iPad/Source/View/Component/ShapeCreatorButton.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol ShapeCreatorButtonDelegate: AnyObject {
-    func didTapShapeButton(_ button: ShapeCreatorButton)
+    func didTapShapeCreatorButton(_ button: ShapeCreatorButton)
 }
 
 final class ShapeCreatorButton: UIButton {
@@ -36,11 +36,11 @@ final class ShapeCreatorButton: UIButton {
         self.setTitleColor(UIColor.black, for: .normal)
         self.addAction(UIAction { [weak self] _ in
             print("버튼눌림")
-            self?.handleButtonTap()
+            self?.handleButtonTapped()
         }, for: .touchUpInside)
     }
     
-    private func handleButtonTap() {
-        delegate?.didTapShapeButton(self)
+    private func handleButtonTapped() {
+        delegate?.didTapShapeCreatorButton(self)
     }
 }

--- a/Drawing-iPad/Source/View/Component/ShapeCreatorButton.swift
+++ b/Drawing-iPad/Source/View/Component/ShapeCreatorButton.swift
@@ -8,16 +8,19 @@
 import UIKit
 
 protocol ShapeCreatorButtonDelegate: AnyObject {
-    func didTapShapeCreatorButton(_ button: ShapeCreatorButton)
+    func didTapShapeCreatorButton(_ button: ShapeCreatorButton,
+                                  shapeCategory: ShapeCategory)
 }
 
 final class ShapeCreatorButton: UIButton {
     weak var delegate: ShapeCreatorButtonDelegate?
     
     private let name: String
+    private let shapeCategory: ShapeCategory
     
-    init(name: String) {
+    init(name: String, shapeCategory: ShapeCategory) {
         self.name = name
+        self.shapeCategory = shapeCategory
         super.init(frame: .zero)
         setupConfiguration()
     }
@@ -41,6 +44,6 @@ final class ShapeCreatorButton: UIButton {
     }
     
     private func handleButtonTapped() {
-        delegate?.didTapShapeCreatorButton(self)
+        delegate?.didTapShapeCreatorButton(self, shapeCategory: self.shapeCategory)
     }
 }

--- a/Drawing-iPad/Source/View/Component/ShapeCreatorButton.swift
+++ b/Drawing-iPad/Source/View/Component/ShapeCreatorButton.swift
@@ -38,7 +38,6 @@ final class ShapeCreatorButton: UIButton {
         self.setTitle(self.name, for: .normal)
         self.setTitleColor(UIColor.black, for: .normal)
         self.addAction(UIAction { [weak self] _ in
-            print("버튼눌림")
             self?.handleButtonTapped()
         }, for: .touchUpInside)
     }

--- a/Drawing-iPad/Source/View/Shape/BaseShapeView.swift
+++ b/Drawing-iPad/Source/View/Shape/BaseShapeView.swift
@@ -1,0 +1,67 @@
+//
+//  BaseShapeView.swift
+//  Drawing-iPad
+//
+//  Created by 박효준 on 9/21/24.
+//
+
+import UIKit
+
+protocol ShapeViewDelegate: AnyObject {
+    func didTapRectangleGesture(_ shapeView: BaseShapeView)
+}
+
+class BaseShapeView: UIView {
+    weak var delegate: ShapeViewDelegate?
+    let shapeID: UUID
+    var isSelected: Bool = false {
+        didSet {
+            updateSelectionState()
+        }
+    }
+    
+    init(shapeID: UUID) {
+        self.shapeID = shapeID
+        super.init(frame: .zero)
+        setupConfiguration()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func updateSelectionState() {
+        if isSelected {
+            self.layer.borderWidth = 5.0
+            self.layer.borderColor = UIColor.black.cgColor
+        } else {
+            self.layer.borderWidth = 0.0
+            self.layer.borderColor = nil
+        }
+    }
+    
+    private func setupConfiguration() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleShapeTapped))
+        self.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc private func handleShapeTapped() {
+        print("BaseShapeView - handleShapeTapped")
+        delegate?.didTapRectangleGesture(self)
+    }
+    
+    func setupFromModel(shape: BaseShape) {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.frame.origin = shape.origin.toCGPoint
+        self.frame.size = shape.size.toCGSize
+        if let shape = shape as? Rectangle {
+            self.backgroundColor = UIColor(
+                red: CGFloat(shape.color.red) / 255.0,
+                green: CGFloat(shape.color.green) / 255.0,
+                blue: CGFloat(shape.color.blue) / 255.0,
+                alpha: shape.alpha.toCGFloat
+            )
+        }
+    }
+}

--- a/Drawing-iPad/Source/View/Shape/BaseShapeView.swift
+++ b/Drawing-iPad/Source/View/Shape/BaseShapeView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol ShapeViewDelegate: AnyObject {
-    func didTapRectangleGesture(_ shapeView: BaseShapeView)
+    func didTapShapeView(_ shapeView: BaseShapeView)
 }
 
 class BaseShapeView: UIView {
@@ -48,7 +48,7 @@ class BaseShapeView: UIView {
     
     @objc private func handleShapeTapped() {
         print("BaseShapeView - handleShapeTapped")
-        delegate?.didTapRectangleGesture(self)
+        delegate?.didTapShapeView(self)
     }
     
     func setupFromModel(shape: BaseShape) {

--- a/Drawing-iPad/Source/View/Shape/PhotoView.swift
+++ b/Drawing-iPad/Source/View/Shape/PhotoView.swift
@@ -1,0 +1,31 @@
+//
+//  PhotoView.swift
+//  Drawing-iPad
+//
+//  Created by 박효준 on 9/21/24.
+//
+
+import UIKit
+
+final class PhotoView: BaseShapeView {
+    private let imageView: UIImageView?
+    
+    init(imageView: UIImageView?, shapeID: UUID) {
+        self.imageView = imageView
+        super.init(shapeID: shapeID)
+        setupConfiguration()
+    }
+    
+    private func setupConfiguration() {
+        guard let imageView = imageView else { return }
+        self.addSubview(imageView)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: self.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
+    }
+}

--- a/Drawing-iPad/Source/View/Shape/PhotoView.swift
+++ b/Drawing-iPad/Source/View/Shape/PhotoView.swift
@@ -20,7 +20,7 @@ final class PhotoView: BaseShapeView {
         guard let imageView = imageView else { return }
         self.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.contentMode = .scaleAspectFill
+        imageView.contentMode = .scaleToFill
         NSLayoutConstraint.activate([
             imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),

--- a/Drawing-iPad/Source/View/Shape/RectangleView.swift
+++ b/Drawing-iPad/Source/View/Shape/RectangleView.swift
@@ -51,15 +51,17 @@ final class RectangleView: UIView {
         delegate?.didTapRectangleGesture(self)
     }
     
-    func setupFromModel(rectangle: Rectangle) {
+    func setupFromModel(shape: BaseShape) {
         self.translatesAutoresizingMaskIntoConstraints = false
-        self.frame.origin = rectangle.origin.toCGPoint
-        self.frame.size = rectangle.size.toCGSize
-        self.backgroundColor = UIColor(
-            red: CGFloat(rectangle.color.red) / 255.0,
-            green: CGFloat(rectangle.color.green) / 255.0,
-            blue: CGFloat(rectangle.color.blue) / 255.0,
-            alpha: rectangle.alpha.toCGFloat
-        )
+        self.frame.origin = shape.origin.toCGPoint
+        self.frame.size = shape.size.toCGSize
+        if let shape = shape as? Rectangle {
+            self.backgroundColor = UIColor(
+                red: CGFloat(shape.color.red) / 255.0,
+                green: CGFloat(shape.color.green) / 255.0,
+                blue: CGFloat(shape.color.blue) / 255.0,
+                alpha: shape.alpha.toCGFloat
+            )
+        }
     }
 }

--- a/Drawing-iPad/Source/View/Shape/RectangleView.swift
+++ b/Drawing-iPad/Source/View/Shape/RectangleView.swift
@@ -7,61 +7,6 @@
 
 import UIKit
 
-protocol RectangleTapGestureDelegate: AnyObject {
-    func didTapRectangleGesture(_ rectangleView: RectangleView)
-}
-
-final class RectangleView: UIView {
-    weak var delegate: RectangleTapGestureDelegate?
-    let rectangleID: UUID
-    var isSelected: Bool = false {
-        didSet {
-            updateSelectionState()
-        }
-    }
+final class RectangleView: BaseShapeView {
     
-    init(rectangleID: UUID) {
-        self.rectangleID = rectangleID
-        super.init(frame: .zero)
-        setupConfiguration()
-    }
-    
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func updateSelectionState() {
-        if isSelected {
-            self.layer.borderWidth = 5.0
-            self.layer.borderColor = UIColor.black.cgColor
-        } else {
-            self.layer.borderWidth = 0.0
-            self.layer.borderColor = nil
-        }
-    }
-    
-    private func setupConfiguration() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleRectangleTapped))
-        self.addGestureRecognizer(tapGesture)
-    }
-    
-    @objc private func handleRectangleTapped() {
-        print("RectangleView - handleRectangleTapped")
-        delegate?.didTapRectangleGesture(self)
-    }
-    
-    func setupFromModel(shape: BaseShape) {
-        self.translatesAutoresizingMaskIntoConstraints = false
-        self.frame.origin = shape.origin.toCGPoint
-        self.frame.size = shape.size.toCGSize
-        if let shape = shape as? Rectangle {
-            self.backgroundColor = UIColor(
-                red: CGFloat(shape.color.red) / 255.0,
-                green: CGFloat(shape.color.green) / 255.0,
-                blue: CGFloat(shape.color.blue) / 255.0,
-                alpha: shape.alpha.toCGFloat
-            )
-        }
-    }
 }

--- a/Drawing-iPad/Source/View/SideView.swift
+++ b/Drawing-iPad/Source/View/SideView.swift
@@ -87,10 +87,12 @@ final class SideView: UIView {
         alphaSlider.isEnabled = false
     }
     
-    func updateRectangleInfo(rectangle: Rectangle) {
-        backgroundColorChangeButton.setTitle(rectangle.color.toHexCode,
-                                             for: .normal)
+    func updateShapeInfo(shape: BaseShape) {
+        if let shape = shape as? Rectangle {
+            backgroundColorChangeButton.setTitle(shape.color.toHexCode,
+                                                 for: .normal)
+        }
         alphaSlider.isEnabled = true
-        alphaSlider.value = rectangle.alpha.toFloat
+        alphaSlider.value = shape.alpha.toFloat
     }
 }

--- a/Drawing-iPad/Source/View/SideView.swift
+++ b/Drawing-iPad/Source/View/SideView.swift
@@ -89,8 +89,11 @@ final class SideView: UIView {
     
     func updateShapeInfo(shape: BaseShape) {
         if let shape = shape as? Rectangle {
-            backgroundColorChangeButton.setTitle(shape.color.toHexCode,
-                                                 for: .normal)
+            backgroundColorChangeButton.isEnabled = true
+            backgroundColorChangeButton.setTitle(shape.color.toHexCode, for: .normal)
+        } else {
+            backgroundColorChangeButton.setTitle("None", for: .normal)
+            backgroundColorChangeButton.isEnabled = false
         }
         alphaSlider.isEnabled = true
         alphaSlider.value = shape.alpha.toFloat

--- a/Drawing-iPad/Source/ViewController/CanvasViewController.swift
+++ b/Drawing-iPad/Source/ViewController/CanvasViewController.swift
@@ -68,22 +68,20 @@ final class CanvasViewController: UIViewController {
 
 extension CanvasViewController: CanvasViewDelegate {
     func didTapShapeCreatorButtonInCanvasView(_ canvasView: CanvasView, shapeCategory: ShapeCategory) {
+        let shape: BaseShape
+        
         switch shapeCategory {
         case .rectangle:
-            factory = RectangleFactory(viewBoundsSize: canvasView.planeViewBoundsSize())
+            let factory = RectangleFactory(viewBoundsSize: canvasView.planeViewBoundsSize())
+            shape = factory.makeShape()
         case .photo:
-            factory = PhotoFactory(viewBoundsSize: canvasView.planeViewBoundsSize())
+            let factory = PhotoFactory(viewBoundsSize: canvasView.planeViewBoundsSize())
+            let imageURL = URL(string: "temp")!
+            shape = factory.makeShape(imageURL: imageURL)
         }
         
-        if let photoFactory = factory as? PhotoFactory {
-            let imageURL = URL(string: "temp")!
-            let photo = photoFactory.makeShape(imageURL: imageURL)
-            plane.appendShape(shape: photo)
-            createShape(photo)
-        } else if let shape = factory?.makeShape() as? Rectangle {
-            plane.appendShape(shape: shape)
-            createShape(shape)
-        }
+        plane.appendShape(shape: shape)
+        createShape(shape)
     }
     
     private func createShape(_ shape: BaseShape) {

--- a/Drawing-iPad/Source/ViewController/CanvasViewController.swift
+++ b/Drawing-iPad/Source/ViewController/CanvasViewController.swift
@@ -152,28 +152,28 @@ extension CanvasViewController: PHPickerViewControllerDelegate {
         guard let provider = results.first?.itemProvider else { return }
         provider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
             guard let self = self,
-                  let selectedimage = image as? UIImage,
-                  let data = selectedimage.pngData() else { return }
+                  let selectedimage = image as? UIImage else { return }
             
             DispatchQueue.main.async {
-                guard let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+                guard let documents = FileManager.default.urls(for: .documentDirectory,
+                                                               in: .userDomainMask).first
+                else { return }
                 let fileName = UUID().uuidString + ".png"
                 let imageURL = documents.appending(path: fileName, directoryHint: .notDirectory)
-                self.createPhoto(imageURL: imageURL)
+                self.createPhoto(image: selectedimage, imageURL: imageURL)
             }
         }
     }
     
-    private func createPhoto(imageURL: URL) {
+    private func createPhoto(image: UIImage, imageURL: URL) {
         let factory = PhotoFactory(viewBoundsSize: canvasView.planeViewBoundsSize())
         let photo = factory.makeShape(imageURL: imageURL)
         
-        let image = UIImage(contentsOfFile: imageURL.path)
         let photoImageView = UIImageView(image: image)
         let photoView = PhotoView(imageView: photoImageView, shapeID: photo.identifier)
         photoView.setupFromModel(shape: photo)
-        canvasView.addShape(shapeView: photoView)
         
         plane.appendShape(shape: photo)
+        canvasView.addShape(shapeView: photoView)
     }
 }

--- a/Drawing-iPad/Source/ViewController/CanvasViewController.swift
+++ b/Drawing-iPad/Source/ViewController/CanvasViewController.swift
@@ -87,20 +87,20 @@ extension CanvasViewController: CanvasViewDelegate {
     private func createShape(_ shape: BaseShape) {
         let shapeView = BaseShapeView(shapeID: shape.identifier)
         shapeView.setupFromModel(shape: shape)
-        canvasView.addRectangle(rectangleView: shapeView)
+        canvasView.addShape(shapeView: shapeView)
     }
     
-    func didTapGestureRectangle(_ canvasView: CanvasView,
-                                rectangleID: UUID) {
+    func didTapGestureShapeView(_ canvasView: CanvasView,
+                                shapeID: UUID) {
         if let previousSelectedView = selectedShapeView {
             previousSelectedView.isSelected = false
         }
         
-        guard let rectangleView = canvasView.rectangleView(withID: rectangleID),
-              let shape = plane.findShape(withID: rectangleID) else { return }
+        guard let shapeView = canvasView.shapeView(withID: shapeID),
+              let shape = plane.findShape(withID: shapeID) else { return }
         
-        rectangleView.isSelected = true
-        selectedShapeView = rectangleView
+        shapeView.isSelected = true
+        selectedShapeView = shapeView
         
         canvasView.updateSideView(shape: shape)
     }

--- a/Drawing-iPad/Source/ViewController/CanvasViewController.swift
+++ b/Drawing-iPad/Source/ViewController/CanvasViewController.swift
@@ -13,7 +13,7 @@ final class CanvasViewController: UIViewController {
     private let canvasView = CanvasView()
     private var factory: (any ShapeCreatable)?
     private let plane = Plane()
-    private var selectedRectangleView: RectangleView?
+    private var selectedShapeView: BaseShapeView?
     
     // MARK: - View LifeCycle
     
@@ -85,14 +85,14 @@ extension CanvasViewController: CanvasViewDelegate {
     }
     
     private func createShape(_ shape: BaseShape) {
-        let rectangleView = RectangleView(rectangleID: shape.identifier)
-        rectangleView.setupFromModel(shape: shape)
-        canvasView.addRectangle(rectangleView: rectangleView)
+        let shapeView = BaseShapeView(shapeID: shape.identifier)
+        shapeView.setupFromModel(shape: shape)
+        canvasView.addRectangle(rectangleView: shapeView)
     }
     
     func didTapGestureRectangle(_ canvasView: CanvasView,
                                 rectangleID: UUID) {
-        if let previousSelectedView = selectedRectangleView {
+        if let previousSelectedView = selectedShapeView {
             previousSelectedView.isSelected = false
         }
         
@@ -100,29 +100,29 @@ extension CanvasViewController: CanvasViewDelegate {
               let shape = plane.findShape(withID: rectangleID) else { return }
         
         rectangleView.isSelected = true
-        selectedRectangleView = rectangleView
+        selectedShapeView = rectangleView
         
         canvasView.updateSideView(shape: shape)
     }
     
     func didTapBackgroundColorChangeButton(_ canvasView: CanvasView) {
-        guard let rectangleView = selectedRectangleView,
-              let shape = plane.findShape(withID: rectangleView.rectangleID) as? Rectangle else { return }
+        guard let shapeView = selectedShapeView,
+              let shape = plane.findShape(withID: shapeView.shapeID) as? Rectangle else { return }
         let newColor = RandomFactory.makeRandomColor()
         
-        rectangleView.backgroundColor = UIColor(
+        shapeView.backgroundColor = UIColor(
             red: CGFloat(newColor.red) / 255.0,
             green: CGFloat(newColor.green) / 255.0,
             blue: CGFloat(newColor.blue) / 255.0,
-            alpha: selectedRectangleView?.alpha ?? .zero
+            alpha: selectedShapeView?.alpha ?? .zero
         )
         shape.updateColor(color: newColor)
     }
     
     func didChangeAlphaSlider(_ canvasView: CanvasView, changedValue: Float) {
-        guard let rectangleView = selectedRectangleView,
-              let shape = plane.findShape(withID: rectangleView.rectangleID) else { return }
-        rectangleView.alpha = CGFloat(changedValue) / 10.0
+        guard let shapeView = selectedShapeView,
+              let shape = plane.findShape(withID: shapeView.shapeID) else { return }
+        shapeView.alpha = CGFloat(changedValue) / 10.0
         
         if let newAlpha = Alpha.from(floatValue: changedValue) {
             shape.updateAlpha(alpha: newAlpha)

--- a/Drawing-iPad/Source/ViewController/CanvasViewController.swift
+++ b/Drawing-iPad/Source/ViewController/CanvasViewController.swift
@@ -73,7 +73,7 @@ final class CanvasViewController: UIViewController {
 // MARK: - CanvasViewDelegate
 
 extension CanvasViewController: CanvasViewDelegate {
-    func didTapShapeButtonInCanvasView(_ canvasView: CanvasView) {
+    func didTapShapeCreatorButtonInCanvasView(_ canvasView: CanvasView) {
         guard let rectangle = factory?.makeRectangle() else { return }
         plane.appendRectangle(rectangle: rectangle)
         createRectangle(rectangle)


### PR DESCRIPTION
### 1. ShapeButton 및 관련 네이밍 변경
- ShapeButton을 ShapeCreatorButton으로 변경하여 명확성을 높임.
- 기존 Rectangle 관련 네이밍을 추상화된 BaseShape로 변경하여 Rectangle 외의 다른 도형도 지원할 수 있도록 함.
- 모든 Rectangle 키워드를 추상화된 Shape 키워드로 변경함.

### 2. ShapeCreator 버튼 클릭 시 팩토리 생성 및 연동
- ShapeCategory 열거형을 추가하여 사각형과 사진을 구분하고, 해당 버튼 클릭 시 팩토리를 생성하는 기능을 구현함.
- 사진 버튼 클릭 시, Photo 모델을 생성하여 Plane에 추가하는 기능을 구현함. ShapeCreatorButton에서 CanvasView를 거쳐 CanvasViewController로 delegate 패턴을 설정하여 전달함.

### 3. BaseShapeView로 뷰 추상화
- RectangleView, PhotoView 등 Shape 관련 뷰를 BaseShapeView로 추상화하여 관리하도록 구현함.
- PhotoView는 BaseShapeView를 상속받고, 이미지 표시를 위한 imageView를 프로퍼티로 가짐.

### 4. PHPickerViewController 연동 및 PhotoView 생성 문제 해결
- PHPickerViewControllerDelegate를 사용해 이미지를 선택하고 PhotoView와 연동하는 기능을 구현함.
- Picker에서 이미지를 선택했을 때 PhotoView가 생성되지 않던 문제를 해결함. 선택된 이미지를 UIImage로 사용하여 PhotoView를 생성하고, 모델에는 이미지를 URL로 변환하여 저장함.

### 5. 이미지 및 UI 관련 문제 해결
- PhotoView에 이미지를 scaleToFill로 설정하여 이미지 크기 문제를 해결함.
- PhotoView 클릭 시, 사이드 뷰의 배경색 버튼을 비활성화하고 'None'으로 표시되도록 구현함. Rectangle만 배경색 조정이 가능하도록 설정함.