### PR TITLE
feat: ShapeView에 PanGesture를 등록하여 드래그 구현

### DIFF
--- a/Drawing-iPad/Source/Model/Core/Point.swift
+++ b/Drawing-iPad/Source/Model/Core/Point.swift
@@ -15,6 +15,14 @@ struct Point: Equatable {
         self.x = x
         self.y = y
     }
+    
+    func xValue() -> Double {
+        return self.x
+    }
+    
+    func yValue() -> Double {
+        return self.y
+    }
 }
 
 extension Point: CustomStringConvertible {

--- a/Drawing-iPad/Source/Model/Core/Size.swift
+++ b/Drawing-iPad/Source/Model/Core/Size.swift
@@ -15,6 +15,14 @@ struct Size {
         self.width = width
         self.height = height
     }
+    
+    func widthValue() -> Double {
+        return self.width
+    }
+    
+    func heightValue() -> Double {
+        return self.height
+    }
 }
 
 extension Size: CustomStringConvertible {

--- a/Drawing-iPad/Source/Model/Shapes/BaseShape.swift
+++ b/Drawing-iPad/Source/Model/Shapes/BaseShape.swift
@@ -48,4 +48,12 @@ class BaseShape: Shapable, AlphaControllable, CustomStringConvertible  {
     func updateAlpha(alpha: Alpha) {
         self.alpha = alpha
     }
+    
+    func updateOrigin(x: Double, y: Double) {
+        self.origin = Point(x: x, y: y)
+    }
+    
+    func updateSize(width: Double, height: Double) {
+        self.size = Size(width: width, height: height)
+    }
 }

--- a/Drawing-iPad/Source/View/CanvasView.swift
+++ b/Drawing-iPad/Source/View/CanvasView.swift
@@ -99,6 +99,10 @@ final class CanvasView: UIView {
         ])
     }
     
+    func addShape(tempView: UIView) {
+        planeView.addSubview(tempView)
+    }
+    
     func planeViewBoundsSize() -> CGSize {
         return planeView.bounds.size
     }

--- a/Drawing-iPad/Source/View/CanvasView.swift
+++ b/Drawing-iPad/Source/View/CanvasView.swift
@@ -10,6 +10,7 @@ import UIKit
 protocol CanvasViewDelegate: AnyObject {
     func didTapShapeCreatorButtonInCanvasView(_ canvasView: CanvasView, shapeCategory: ShapeCategory)
     func didTapGestureShapeView(_ canvasView: CanvasView, shapeID: UUID)
+    func didPanGestureShapeView(_ canvasView: CanvasView, shapeID: UUID, sender: UIPanGestureRecognizer)
     func didTapBackgroundColorChangeButton(_ canvasView: CanvasView)
     func didChangeAlphaSlider(_ canvasView: CanvasView, changedValue: Float)
 }
@@ -122,6 +123,10 @@ extension CanvasView: ShapeCreatorButtonDelegate {
 extension CanvasView: ShapeViewDelegate {
     func didTapShapeView(_ shapeView: BaseShapeView) {
         delegate?.didTapGestureShapeView(self, shapeID: shapeView.shapeID)
+    }
+    
+    func didPanShapeView(_ shapeView: BaseShapeView, sender: UIPanGestureRecognizer) {
+        delegate?.didPanGestureShapeView(self, shapeID: shapeView.shapeID, sender: sender)
     }
     
     func updateSideView(shape: BaseShape) {

--- a/Drawing-iPad/Source/View/Shape/BaseShapeView.swift
+++ b/Drawing-iPad/Source/View/Shape/BaseShapeView.swift
@@ -47,6 +47,8 @@ class BaseShapeView: UIView {
         self.addGestureRecognizer(tapGesture)
         
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handleShapePan))
+        panGesture.minimumNumberOfTouches = 1
+        panGesture.maximumNumberOfTouches = 1
         self.addGestureRecognizer(panGesture)
     }
     

--- a/Drawing-iPad/Source/ViewController/CanvasViewController.swift
+++ b/Drawing-iPad/Source/ViewController/CanvasViewController.swift
@@ -15,6 +15,8 @@ final class CanvasViewController: UIViewController {
     private var factory: (any ShapeCreatable)?
     private let plane = Plane()
     private var selectedShapeView: BaseShapeView?
+    private var selectedShapeViewIndex: Int?
+    private var temporaryView: UIView?
     
     // MARK: View LifeCycle
     
@@ -101,8 +103,7 @@ extension CanvasViewController: CanvasViewDelegate {
     
     // MARK: Tap Gesture
     
-    func didTapGestureShapeView(_ canvasView: CanvasView,
-                                shapeID: UUID) {
+    func didTapGestureShapeView(_ canvasView: CanvasView, shapeID: UUID) {
         if let previousSelectedView = selectedShapeView {
             previousSelectedView.isSelected = false
         }
@@ -114,6 +115,64 @@ extension CanvasViewController: CanvasViewDelegate {
         selectedShapeView = shapeView
         
         canvasView.updateSideView(shape: shape)
+    }
+    
+    // MARK: Pan Gesture
+    
+    func didPanGestureShapeView(_ canvasView: CanvasView, shapeID: UUID, sender: UIPanGestureRecognizer) {
+        guard let shapeView = canvasView.shapeView(withID: shapeID) else { return }
+        let translation = sender.translation(in: canvasView)
+        
+        switch sender.state {
+        case .began:
+            createTemporaryView(shapeView: shapeView)
+        case .changed:
+            temporaryView?.center = CGPoint(
+                x: shapeView.center.x + translation.x,
+                y: shapeView.center.y + translation.y
+            )
+            sender.setTranslation(.zero, in: canvasView)
+            
+            if let tempView = temporaryView {
+                updateShapeModelPosition(origin: tempView.frame.origin)
+            }
+        case .ended, .cancelled:
+            shapeView.center = CGPoint(
+                x: shapeView.center.x + translation.x,
+                y: shapeView.center.y + translation.y
+            )
+            finishDragging(shapeView: shapeView)
+            sender.setTranslation(.zero, in: canvasView)
+        default:
+            break
+        }
+    }
+    
+    func createTemporaryView(shapeView: BaseShapeView) {
+        temporaryView = shapeView.snapshotView(afterScreenUpdates: false)
+        temporaryView?.alpha = 0.5
+        temporaryView?.center = shapeView.center
+        canvasView.addShape(tempView: temporaryView!)
+    }
+    
+    func finishDragging(shapeView: BaseShapeView) {
+        guard let temporaryView = temporaryView else { return }
+        temporaryView.removeFromSuperview()
+        
+        let origin = temporaryView.frame.origin
+        let size = temporaryView.frame.size
+        
+        shapeView.updateFrame(origin: Point(x: origin.x, y: origin.y),
+                              size: Size(width: size.width, height: size.height))
+        updateShapeModelPosition(origin: shapeView.frame.origin)
+    }
+    
+    func updateShapeModelPosition(origin: CGPoint) {
+        guard let index = selectedShapeViewIndex,
+              let shape = plane[index] else { return }
+        
+        shape.updateOrigin(x: origin.x, y: origin.y)
+        print("모델 데이터 좌표 업데이트: \(shape.origin)")
     }
     
     // MARK: SideView

--- a/Drawing-iPad/Source/ViewController/CanvasViewController.swift
+++ b/Drawing-iPad/Source/ViewController/CanvasViewController.swift
@@ -127,13 +127,13 @@ extension CanvasViewController: CanvasViewDelegate {
         case .began:
             createTemporaryView(shapeView: shapeView)
         case .changed:
-            temporaryView?.center = CGPoint(
-                x: shapeView.center.x + translation.x,
-                y: shapeView.center.y + translation.y
-            )
-            sender.setTranslation(.zero, in: canvasView)
-            
             if let tempView = temporaryView {
+                tempView.center = CGPoint(
+                    x: tempView.center.x + translation.x,
+                    y: tempView.center.y + translation.y
+                )
+                sender.setTranslation(.zero, in: canvasView)
+                print("changed: \(tempView.frame.origin)")
                 updateShapeModelPosition(origin: tempView.frame.origin)
             }
         case .ended, .cancelled:

--- a/Drawing-iPad/Source/ViewController/CanvasViewController.swift
+++ b/Drawing-iPad/Source/ViewController/CanvasViewController.swift
@@ -133,7 +133,6 @@ extension CanvasViewController: CanvasViewDelegate {
                     y: tempView.center.y + translation.y
                 )
                 sender.setTranslation(.zero, in: canvasView)
-                print("changed: \(tempView.frame.origin)")
                 updateShapeModelPosition(origin: tempView.frame.origin)
             }
         case .ended, .cancelled:
@@ -172,7 +171,6 @@ extension CanvasViewController: CanvasViewDelegate {
               let shape = plane[index] else { return }
         
         shape.updateOrigin(x: origin.x, y: origin.y)
-        print("모델 데이터 좌표 업데이트: \(shape.origin)")
     }
     
     // MARK: SideView


### PR DESCRIPTION
### 1. Shape 모델에 getter와 setter 추가
- Shape 모델에 getter와 setter를 추가하였으며, `get`과 `set` 키워드는 사용하지 않음.

### 2. ShapeView에 PanGesture 등록 및 드래그 구현
- ShapeView에 PanGesture를 등록하여 드래그 기능을 구현함.
- PanGesture를 이용한 드래그가 가능하지만, 아직 불안정한 부분이 있음.

### 3. 임시뷰의 움직임 개선
- PanGesture의 `changed` 상태에서 임시뷰가 제대로 움직이지 않는 문제를 개선함.
- 로직을 수정하여 임시뷰의 움직임을 더 자연스럽게 처리함.